### PR TITLE
handle HTTP status code 204

### DIFF
--- a/code/api/src/index.ts
+++ b/code/api/src/index.ts
@@ -588,7 +588,7 @@ by default I will ask for all rights`);
             if (this.listenerCount('debug')) {
                 this.emit('debug', `[OVH] API response to ${method} ${path}: ${body}`);
             }
-            if (statusCode === 200) {
+            if (statusCode === 200 || statusCode === 204) {
                 if (cacheSilot) {
                     if (method === 'GET')
                         await cacheSilot.store(path, responseData, size);

--- a/code/api/src/index.ts
+++ b/code/api/src/index.ts
@@ -588,7 +588,7 @@ by default I will ask for all rights`);
             if (this.listenerCount('debug')) {
                 this.emit('debug', `[OVH] API response to ${method} ${path}: ${body}`);
             }
-            if (statusCode === 200 || statusCode === 204) {
+            if (statusCode >= 200 && statusCode < 300) {
                 if (cacheSilot) {
                     if (method === 'GET')
                         await cacheSilot.store(path, responseData, size);


### PR DESCRIPTION
Hello,

Only the http 200 status code is taken into account, but OVH seems to respond with a code 204. 

So I have this kind of error: 

```javascript
// pseudo code
cloud.kube.NodePool.$(nodepoolId).$put({
   maxNodes: 5
})
```

```
/apps/ovh_cli/node_modules/@ovh-api/api/dist/index.js:436
                error.errorCode = "HTTP_ERROR";
                                ^
TypeError: Cannot create property 'errorCode' on string ''
    at handleResponse (/apps/ovh_cli/node_modules/@ovh-api/api/dist/index.js:436:33)
    at IncomingMessage.<anonymous> (/apps/ovh_cli/node_modules/@ovh-api/api/dist/index.js:477:28)
    at IncomingMessage.emit (node:events:381:22)
    at IncomingMessage.emit (node:domain:470:12)
    at endReadableNT (node:internal/streams/readable:1307:12)
    at processTicksAndRejections (node:internal/process/task_queues:81:21)
```

It may be possible to expand to all code 2XX
